### PR TITLE
delete `window.intercomSettings` on `shutdown`

### DIFF
--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -123,6 +123,7 @@ export const IntercomProvider: React.FC<React.PropsWithChildren<
     if (!isBooted.current) return;
 
     IntercomAPI('shutdown');
+    delete window.intercomSettings;
     isBooted.current = false;
   }, []);
 


### PR DESCRIPTION
this library adds a new piece of data to `window`: `window.intercomSettings`. this piece of data contains data about the intercom user, like their name, email, and even the `user_hash`, which is a security token used to guarantee the user chatting with you is who they say they are.

This data should be cleared whenever logging out of your application, otherwise that `user_hash` and other user information is sitting around in the tab after the user has logged out.

`shutdown` is the API you are supposed to call when logging out, so this function should do this cleanup, too.

`hardShutdown` does this already, but it also deletes `window.Intercom`. That's problematic because if someone logs back in in the same session/tab, you don't want `window.Intercom` to be missing (nothing adds it back)